### PR TITLE
Throw invalidConversion if FluentPersistDriver.get(key:as:) fails to convert object 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,11 +11,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.5"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.5.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.49.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
         // used in tests
-        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.0"),
+        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.8.0"),
     ],
     targets: [
         .target(

--- a/Sources/HummingbirdFluent/Fluent.swift
+++ b/Sources/HummingbirdFluent/Fluent.swift
@@ -72,7 +72,7 @@ public struct Fluent: Sendable, Service {
 
     /// Shutdown Fluent databases
     public func shutdown() async throws {
-        self.databases.shutdown()
+        await self.databases.shutdownAsync()
     }
 
     /// Return Database connection

--- a/Sources/HummingbirdFluent/Persist+fluent.swift
+++ b/Sources/HummingbirdFluent/Persist+fluent.swift
@@ -90,7 +90,11 @@ public final class FluentPersistDriver: PersistDriver {
                 .filter(\.$expires > Date())
                 .first()
             guard let data = query?.data else { return nil }
-            return try JSONDecoder().decode(object, from: data)
+            do {
+                return try JSONDecoder().decode(object, from: data)
+            } catch is DecodingError {
+                throw PersistError.invalidConversion
+            }
         }
     }
 

--- a/Tests/HummingbirdFluentTests/PersistTests.swift
+++ b/Tests/HummingbirdFluentTests/PersistTests.swift
@@ -181,6 +181,31 @@ final class PersistTests: XCTestCase {
         }
     }
 
+    func testInvalidGetAs() async throws {
+        struct TestCodable: Codable {
+            let buffer: String
+        }
+        let app = try await self.createApplication { router, persist in
+            router.put("/invalid") { _, _ -> HTTPResponse.Status in
+                try await persist.set(key: "test", value: TestCodable(buffer: "hello"))
+                return .ok
+            }
+            router.get("/invalid") { _, _ -> String? in
+                do {
+                    return try await persist.get(key: "test", as: String.self)
+                } catch let error as PersistError where error == .invalidConversion {
+                    throw HTTPError(.badRequest)
+                }
+            }
+        }
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/invalid", method: .put)
+            try await client.execute(uri: "/invalid", method: .get) { response in
+                XCTAssertEqual(response.status, .badRequest)
+            }
+        }
+    }
+
     func testRemove() async throws {
         let app = try await self.createApplication()
         try await app.test(.live) { client in


### PR DESCRIPTION
I also updated to use async fluent shutdown methods